### PR TITLE
MAJOR: set a channel per engine-id

### DIFF
--- a/spoe/hello.go
+++ b/spoe/hello.go
@@ -15,6 +15,7 @@ const (
 	helloKeyVersion           = "version"
 	helloKeyCapabilities      = "capabilities"
 	helloKeyHealthcheck       = "healthcheck"
+	helloKeyEngineId          = "engine-id"
 
 	capabilityAsync      = "async"
 	capabilityPipelining = "pipelining"
@@ -72,6 +73,11 @@ func (c *conn) handleHello(frame frame) (frame, bool, error) {
 
 	if !checkCapabilities(remoteCapabilities) {
 		return frame, false, fmt.Errorf("hello: expected capabilities %v", helloCapabilities)
+	}
+
+	c.engineID, _ = data[helloKeyEngineId].(string)
+	if len(c.engineID) == 0 {
+		return frame, false, fmt.Errorf("hello: engine-id not found")
 	}
 
 	frame.ftype = frameTypeAgentHello


### PR DESCRIPTION
Each HAProxy process owns an engine ID. When you reload HAProxy, it will
compute a new engine ID.
The ASYNC mode of SPOE applies to all connections pointing to a same
engine-id.
Since the current implementation does not take into account the
engine-id when sending an ACK, it may be possible that an ACK is sent to
the wrong HAProxy client.

This patch fixes this issue by creating one channel per engine id, so
there is no chance to send an ACK to a wrong connection.